### PR TITLE
get civil file content document support

### DIFF
--- a/src/libs/ords-pcss-client/ords.pcss.swagger.yaml
+++ b/src/libs/ords-pcss-client/ords.pcss.swagger.yaml
@@ -96,7 +96,28 @@ paths:
           in: query
           type: string
           description: Implicit parameter  
-          pattern: '^[^/]+$'      
+          pattern: '^[^/]+$'
+  '/civil/file-content/document-support/':
+    get:
+      tags:
+      - PCSS-CIVIL
+      security:
+      - basicAuth: []      
+      description: Get the civil file content document support data
+      responses:
+        '200':
+          description: output of the endpoint
+          schema:
+            type: object
+            properties:
+              data:
+                $ref: '#/definitions/civilFileContentDocumentSupportResponse'
+      parameters:
+        - name: civil_document_id
+          in: query
+          type: string
+          description: Implicit parameter
+          pattern: '^[^/]+$'
   '/civil/file-content/hearing-restrictions/':
     get:
       tags:
@@ -409,7 +430,25 @@ definitions:
       lastappearnacedt:
         type: string
       lastappearancetm:
-        type: string                                                                                                                                                   
+        type: string
+  civilFileContentDocumentSupportResponse:
+    type: object
+    properties:
+      data:
+        type: array
+        items:
+          $ref: '#/definitions/civilFileContentDocumentSupportData'
+      response_cd:
+        type: number
+      response_msg:
+        type: string
+  civilFileContentDocumentSupportData:
+    type: object
+    properties:
+      actcd:
+        type: string
+      actdsc:
+        type: string
   searchFileAppearanceResponse:
     type: object
     properties:


### PR DESCRIPTION
# Description

This PR includes the following proposed change(s):

Jira - PIM-19
update swagger yaml for new ORDS GET endpoint /civil/file-content/document-support/

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Refactoring / Documentation

if your change is a breaking change, please add `breaking change` label to this PR

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes.

## Checklist:

- [ ] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] New and existing unit tests pass locally with my changes
